### PR TITLE
Add SQLAlchemy models and data dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,5 @@ htmlcov/
 
 # OS
 Thumbs.db
-!
-data/.gitkeep
+!data/.gitkeep
 !instance/.gitkeep

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,8 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Global SQLAlchemy database instance
+# Initialized in application factory
+# Use: from app import db
+
+
+db = SQLAlchemy()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,156 @@
+"""SQLAlchemy ORM models for meta-analysis database."""
+
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import db
+
+
+class Study(db.Model):
+    """Primary study information."""
+
+    __tablename__ = "study"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    year: Mapped[int | None] = mapped_column(db.Integer)
+    journal: Mapped[str | None] = mapped_column(db.String(255))
+    doi: Mapped[str | None] = mapped_column(db.String(255), unique=True)
+    authors_text: Mapped[str | None] = mapped_column(db.Text)
+    country: Mapped[str | None] = mapped_column(db.String(128))
+    design: Mapped[str | None] = mapped_column(db.String(128))
+    notes: Mapped[str | None] = mapped_column(db.Text)
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        db.DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    arms: Mapped[list["Arm"]] = relationship(back_populates="study")
+    outcomes: Mapped[list["Outcome"]] = relationship(back_populates="study")
+    effects: Mapped[list["Effect"]] = relationship(back_populates="study")
+    covariates: Mapped[list["Covariate"]] = relationship(back_populates="study")
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="study_tag", back_populates="studies"
+    )
+
+
+class Arm(db.Model):
+    """Participant arm within a study."""
+
+    __tablename__ = "arm"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"), index=True)
+    name: Mapped[str | None] = mapped_column(db.String(128))
+    n: Mapped[int | None] = mapped_column(db.Integer)
+    desc: Mapped[str | None] = mapped_column(db.Text)
+
+    study: Mapped[Study] = relationship(back_populates="arms")
+
+    __table_args__ = (CheckConstraint("n >= 0", name="ck_arm_n_nonnegative"),)
+
+
+class Outcome(db.Model):
+    """Measured outcome within a study."""
+
+    __tablename__ = "outcome"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"), index=True)
+    name: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    unit: Mapped[str | None] = mapped_column(db.String(64))
+    direction: Mapped[str | None] = mapped_column(db.String(16))
+    domain: Mapped[str | None] = mapped_column(db.String(64))
+
+    study: Mapped[Study] = relationship(back_populates="outcomes")
+    effects: Mapped[list["Effect"]] = relationship(back_populates="outcome")
+
+
+class Effect(db.Model):
+    """Effect size or arm-level statistics."""
+
+    __tablename__ = "effect"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"), nullable=False)
+    outcome_id: Mapped[int] = mapped_column(db.ForeignKey("outcome.id"), nullable=False)
+    arm_id: Mapped[int | None] = mapped_column(db.ForeignKey("arm.id"))
+    arm_treat_id: Mapped[int | None] = mapped_column(db.ForeignKey("arm.id"))
+    arm_ctrl_id: Mapped[int | None] = mapped_column(db.ForeignKey("arm.id"))
+    effect_type: Mapped[str] = mapped_column(
+        db.Enum("SMD", "MD", "logOR", "RR", name="effect_type_enum"),
+        nullable=False,
+    )
+    effect: Mapped[float | None] = mapped_column(db.Float)
+    se: Mapped[float | None] = mapped_column(db.Float)
+    ci_low: Mapped[float | None] = mapped_column(db.Float)
+    ci_high: Mapped[float | None] = mapped_column(db.Float)
+    mean: Mapped[float | None] = mapped_column(db.Float)
+    sd: Mapped[float | None] = mapped_column(db.Float)
+    n: Mapped[int | None] = mapped_column(db.Integer)
+    events: Mapped[int | None] = mapped_column(db.Integer)
+    total: Mapped[int | None] = mapped_column(db.Integer)
+
+    study: Mapped[Study] = relationship(back_populates="effects")
+    outcome: Mapped[Outcome] = relationship(back_populates="effects")
+    arm: Mapped[Arm | None] = relationship(foreign_keys=[arm_id])
+    arm_treat: Mapped[Arm | None] = relationship(foreign_keys=[arm_treat_id])
+    arm_ctrl: Mapped[Arm | None] = relationship(foreign_keys=[arm_ctrl_id])
+
+    __table_args__ = (
+        CheckConstraint("n >= 0", name="ck_effect_n_nonnegative"),
+        CheckConstraint("sd >= 0", name="ck_effect_sd_nonnegative"),
+        CheckConstraint("events <= total", name="ck_effect_events_total"),
+        Index("ix_effect_outcome_study", "outcome_id", "study_id"),
+    )
+
+
+class Covariate(db.Model):
+    """Covariate value for a study."""
+
+    __tablename__ = "covariate"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"))
+    name: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    value: Mapped[str | None] = mapped_column(db.String(255))
+
+    study: Mapped[Study] = relationship(back_populates="covariates")
+
+
+study_tag = db.Table(
+    "study_tag",
+    db.Column("study_id", db.Integer, db.ForeignKey("study.id"), primary_key=True),
+    db.Column("tag_id", db.Integer, db.ForeignKey("tag.id"), primary_key=True),
+)
+
+
+class Tag(db.Model):
+    """Tag assigned to studies."""
+
+    __tablename__ = "tag"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(db.String(64), unique=True, nullable=False)
+
+    studies: Mapped[list[Study]] = relationship(
+        secondary=study_tag, back_populates="tags"
+    )
+
+
+class User(db.Model):
+    """Application user (not yet used)."""
+
+    __tablename__ = "user"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(db.String(255), unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    role: Mapped[str] = mapped_column(db.String(64), nullable=False, default="user")

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -1,0 +1,70 @@
+# Data Dictionary
+
+This document lists the database tables and their fields.
+
+## Study
+- **id** (`Integer`): Primary key.
+- **title** (`String`): Study title.
+- **year** (`Integer`): Publication year.
+- **journal** (`String`): Journal name.
+- **doi** (`String`, unique): Digital Object Identifier.
+- **authors_text** (`Text`): Authors as provided in source.
+- **country** (`String`): Country of origin.
+- **design** (`String`): Study design.
+- **notes** (`Text`): Additional notes.
+- **created_at** (`DateTime`): Creation timestamp.
+- **updated_at** (`DateTime`): Last modification timestamp.
+
+## Arm
+- **id** (`Integer`): Primary key.
+- **study_id** (`Integer`, FK): Related study.
+- **name** (`String`): Arm label.
+- **n** (`Integer`): Sample size.
+- **desc** (`Text`): Description.
+
+## Outcome
+- **id** (`Integer`): Primary key.
+- **study_id** (`Integer`, FK): Related study.
+- **name** (`String`): Outcome name.
+- **unit** (`String`): Measurement unit.
+- **direction** (`String`): Direction of effect.
+- **domain** (`String`): Outcome domain.
+
+## Effect
+- **id** (`Integer`): Primary key.
+- **study_id** (`Integer`, FK): Related study.
+- **outcome_id** (`Integer`, FK): Related outcome.
+- **arm_id** (`Integer`, FK, nullable): Arm-specific effect.
+- **arm_treat_id** (`Integer`, FK, nullable): Treatment arm for comparative effect.
+- **arm_ctrl_id** (`Integer`, FK, nullable): Control arm for comparative effect.
+- **effect_type** (`Enum`): SMD, MD, logOR or RR.
+- **effect** (`Float`): Effect size.
+- **se** (`Float`): Standard error.
+- **ci_low** (`Float`): Lower confidence interval.
+- **ci_high** (`Float`): Upper confidence interval.
+- **mean** (`Float`): Mean value.
+- **sd** (`Float`): Standard deviation.
+- **n** (`Integer`): Sample size.
+- **events** (`Integer`): Number of events.
+- **total** (`Integer`): Total participants.
+
+## Covariate
+- **id** (`Integer`): Primary key.
+- **study_id** (`Integer`, FK): Related study.
+- **name** (`String`): Covariate name.
+- **value** (`String`): Covariate value.
+
+## Tag
+- **id** (`Integer`): Primary key.
+- **name** (`String`, unique): Tag name.
+
+## StudyTag
+- **study_id** (`Integer`, FK): Study reference.
+- **tag_id** (`Integer`, FK): Tag reference.
+
+## User
+- **id** (`Integer`): Primary key.
+- **email** (`String`, unique): Email address.
+- **password_hash** (`String`): Password hash.
+- **role** (`String`): User role.
+

--- a/docs/mapping_excel_to_db.md
+++ b/docs/mapping_excel_to_db.md
@@ -1,0 +1,11 @@
+# Mapping Excel to Database
+
+Preliminary mapping between spreadsheet columns and database fields. To be refined in M4.
+
+- **Study sheet** → `study` table fields.
+- **Arms sheet** → `arm` table.
+- **Outcomes sheet** → `outcome` table.
+- **Effects sheet** → `effect` table.
+- **Covariates sheet** → `covariate` table.
+- **Tags sheet** → `tag` and `study_tag` tables.
+


### PR DESCRIPTION
## Summary
- implement core SQLAlchemy models (Study, Arm, Outcome, Effect, Covariate, Tag, User) with constraints and relations
- provide initial data dictionary and Excel-to-database mapping docs
- fix invalid pattern in `.gitignore`

## Testing
- `python - <<'PY'
from app.models import Study, Arm, Outcome, Effect, Covariate, Tag, User
print('import ok')
PY`
- `black app/__init__.py app/models.py`
- `ruff check app/__init__.py app/models.py`
- `pre-commit run --files app/__init__.py app/models.py docs/data_dictionary.md docs/mapping_excel_to_db.md` *(fails: unable to access https://github.com/psf/black/)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ab52d008328947fbe0912882038