### PR TITLE
feat: add bootstrap layout and form macros

### DIFF
--- a/docs/ui_crud.md
+++ b/docs/ui_crud.md
@@ -1,0 +1,12 @@
+# UI CRUD Overview
+
+This document tracks progress toward the GUI described in the project plan. Screenshots should be added after pages are implemented.
+
+## Layout
+- Bootstrap 5 skeleton with navbar and flash messaging
+- HTMX is referenced for progressive enhancement
+
+## Pending
+- Replace placeholder Bootstrap/HTMX files with real assets
+- Implement list and detail views for Studies, Outcomes and Effects
+- Add screenshots demonstrating CRUD flows

--- a/static/css/bootstrap.min.css
+++ b/static/css/bootstrap.min.css
@@ -1,0 +1,1 @@
+/* Bootstrap placeholder - add real file */

--- a/static/js/bootstrap.bundle.min.js
+++ b/static/js/bootstrap.bundle.min.js
@@ -1,0 +1,1 @@
+// Bootstrap JS placeholder - add real file

--- a/static/js/htmx.min.js
+++ b/static/js/htmx.min.js
@@ -1,0 +1,1 @@
+// HTMX placeholder - add real file

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,3 +1,5 @@
-<!doctype html>
-<title>App is up</title>
+{% extends 'layout.html' %}
+{% block title %}Home - Cytokines{% endblock %}
+{% block content %}
 <h1>App is up</h1>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en" hx-boost="true">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}Cytokines Meta-Analysis{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('core.index') }}">Cytokines</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <form class="d-flex ms-auto me-3" action="{{ url_for('core.index') }}" method="get">
+            <input class="form-control" type="search" placeholder="Search" aria-label="Search" name="q">
+          </form>
+          <ul class="navbar-nav">
+            <li class="nav-item"><a class="nav-link" href="#">Studies</a></li>
+            <li class="nav-item"><a class="nav-link" href="#">Outcomes</a></li>
+            <li class="nav-item"><a class="nav-link" href="#">Effects</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container mt-3">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+
+      {% block breadcrumbs %}{% endblock %}
+      {% block content %}{% endblock %}
+    </div>
+
+    <script src="{{ url_for('static', filename='js/htmx.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+  </body>
+</html>

--- a/templates/macros/forms.html
+++ b/templates/macros/forms.html
@@ -1,0 +1,16 @@
+{% macro render_field(field, prepend=None, append=None, help=None) %}
+  <div class="mb-3">
+    {% if field.label %}
+      <label class="form-label" for="{{ field.id }}">{{ field.label.text }}{% if field.flags.required %}<span class="text-danger">*</span>{% endif %}</label>
+    {% endif %}
+    <div class="{% if prepend or append %}input-group{% endif %}">
+      {% if prepend %}<span class="input-group-text">{{ prepend }}</span>{% endif %}
+      {{ field(class="form-control", id=field.id) }}
+      {% if append %}<span class="input-group-text">{{ append }}</span>{% endif %}
+    </div>
+    {% if help %}<div class="form-text">{{ help }}</div>{% endif %}
+    {% for error in field.errors %}
+      <div class="invalid-feedback d-block">{{ error }}</div>
+    {% endfor %}
+  </div>
+{% endmacro %}

--- a/templates/macros/pagination.html
+++ b/templates/macros/pagination.html
@@ -1,0 +1,31 @@
+{% macro render_pagination(pagination, endpoint) %}
+  {% if pagination.pages > 1 %}
+    <nav aria-label="Page navigation">
+      <ul class="pagination">
+        {% set args = request.args.to_dict() %}
+        {% if pagination.has_prev %}
+          {% set args = args.update({'page': pagination.prev_num}) %}
+          <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, **request.args, page=pagination.prev_num) }}">&laquo;</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        {% endif %}
+        {% for p in pagination.iter_pages() %}
+          {% if p %}
+            {% if p == pagination.page %}
+              <li class="page-item active"><span class="page-link">{{ p }}</span></li>
+            {% else %}
+              <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, **request.args, page=p) }}">{{ p }}</a></li>
+            {% endif %}
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">…</span></li>
+          {% endif %}
+        {% endfor %}
+        {% if pagination.has_next %}
+          <li class="page-item"><a class="page-link" href="{{ url_for(endpoint, **request.args, page=pagination.next_num) }}">&raquo;</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        {% endif %}
+      </ul>
+    </nav>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Summary
- scaffold Bootstrap-based layout with navbar, search, and flash messages
- add Jinja form and pagination macros
- introduce placeholder static assets and initial UI CRUD documentation

## Testing
- `pre-commit run --files templates/layout.html templates/index.html templates/macros/forms.html templates/macros/pagination.html static/css/bootstrap.min.css static/js/bootstrap.bundle.min.js static/js/htmx.min.js` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd80d9bde48328b1fee488869e35cb