### PR TITLE
Define Flask-Login user loader

### DIFF
--- a/app/extensions.py
+++ b/app/extensions.py
@@ -6,3 +6,11 @@ from flask_login import LoginManager
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    """Return user by ID for Flask-Login."""
+    from .models import User
+
+    return db.session.get(User, int(user_id))


### PR DESCRIPTION
## Summary
- add `user_loader` callback so Flask-Login can load users by id

## Testing
- `pre-commit run --files app/extensions.py` (fails: CONNECT tunnel failed, response 403)
- `pytest`
- `python - <<'PY'
from app import create_app
app=create_app()
client=app.test_client()
resp=client.get('/')
print('status', resp.status_code)
print('data', resp.data[:50])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bd848312bc83288bbcb621e411fdd4