### PR TITLE
Warn when importing spreadsheet with no data

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -134,6 +134,11 @@ def _import_data(frames: dict[str, pd.DataFrame], dry_run: bool, replace: bool) 
         db.session.rollback()
         return
 
+    if not objects:
+        click.echo("No data found to import. Check sheet names and required fields.")
+        db.session.rollback()
+        return
+
     if dry_run:
         click.echo("Dry run successful. No data committed.")
         db.session.rollback()


### PR DESCRIPTION
## Summary
- ensure CLI import command reports when no data is loaded rather than silently succeeding

## Testing
- `pre-commit run --files app/cli.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd8c88e32083289c340ba7e7e029fa