### PR TITLE
Add XLSX parser for meta-analysis workbook

### DIFF
--- a/app/xlsx_parser.py
+++ b/app/xlsx_parser.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+"""Utilities for parsing the project's primary XLSX data file.
+
+The workbook contains a single sheet named ``Arkusz1`` with 49 columns.
+This module exposes :func:`load_metaanalysis_xlsx` which loads the file
+and returns a list of dictionaries with properly typed values.
+
+Parsing rules implemented according to the specification provided:
+
+* Leading/trailing whitespace in header names is stripped.
+* Empty strings/``NaN`` values are normalised to ``None``.
+* Yes/No fields are converted to booleans.
+"""
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Column metadata
+# ---------------------------------------------------------------------------
+
+# Columns that should be interpreted as integers
+INT_FIELDS: set[str] = {
+    "Year",
+    "n",
+    "NYHA Scale",
+}
+
+# Columns that should be interpreted as floats
+FLOAT_FIELDS: set[str] = {
+    "Age (mean / median)",
+    "Age (SD / IQR)",
+    "% Males",
+    "Cytokine contrentration mean / median",
+    "Cytokine concentration SD / IQR",
+    "LVEF %",
+    "CRP",
+    "NT-proBNP",
+    "cTnT",
+    "cTnI",
+    "Follow-up time (months)",
+}
+
+# Columns that should be mapped from Yes/No to boolean values
+BOOL_FIELDS: set[str] = {
+    "Inflammation excluded by EMB",
+    "CAD excluded",
+    "EMB performed?",
+    "cMRI performed",
+}
+
+BOOL_MAP = {"yes": True, "no": False}
+
+
+def _normalise_empty(frame: pd.DataFrame) -> pd.DataFrame:
+    """Replace empty strings with ``pd.NA`` for uniform processing."""
+
+    return frame.replace({"": pd.NA})
+
+
+def _coerce_dtypes(frame: pd.DataFrame) -> pd.DataFrame:
+    """Coerce columns to their target dtypes as defined above."""
+
+    for col in BOOL_FIELDS:
+        if col in frame.columns:
+            frame[col] = (
+                frame[col]
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .map(BOOL_MAP)
+            )
+    for col in INT_FIELDS:
+        if col in frame.columns:
+            frame[col] = pd.to_numeric(frame[col], errors="coerce").astype("Int64")
+    for col in FLOAT_FIELDS:
+        if col in frame.columns:
+            frame[col] = pd.to_numeric(frame[col], errors="coerce").astype(float)
+    return frame
+
+
+def _replace_nan_with_none(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert any ``NaN`` values in records into ``None``."""
+
+    cleaned: list[dict[str, Any]] = []
+    for rec in records:
+        row: dict[str, Any] = {}
+        for key, value in rec.items():
+            if isinstance(value, pd._libs.missing.NAType) or pd.isna(value):
+                row[key] = None
+            else:
+                row[key] = value
+        cleaned.append(row)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def load_metaanalysis_xlsx(path: str | Path) -> list[dict[str, Any]]:
+    """Load the given XLSX file and return a list of row dictionaries.
+
+    Parameters
+    ----------
+    path:
+        Path to the workbook. Only the ``Arkusz1`` sheet is processed.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        A list of dictionaries with columns mapped to Python native types.
+    """
+
+    sheet_name = "Arkusz1"
+    frame = pd.read_excel(path, sheet_name=sheet_name, header=0)
+    # Normalise header names by stripping whitespace
+    frame.columns = [c.strip() for c in frame.columns]
+    frame = _normalise_empty(frame)
+    frame = _coerce_dtypes(frame)
+    # Convert to list of dictionaries and replace NaN with None
+    records = frame.to_dict(orient="records")
+    return _replace_nan_with_none(records)

--- a/tests/test_xlsx_parser.py
+++ b/tests/test_xlsx_parser.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.xlsx_parser import load_metaanalysis_xlsx
+
+
+def _create_sample_xlsx(path):
+    data = {
+        "ID": ["M00022", "M00221"],
+        "First author": ["Bielecka-Dabrowa", "Guerra-de-Blas"],
+        "Year": [2013, 2022],
+        "Country": ["Poland", "Mexico"],
+        "Study type": [
+            "RCT - mean value after treatment",
+            "Observational study",
+        ],
+        "n": [30, 80],
+        "Age (mean / median)": [58.4, 51],
+        "Age (SD / IQR)": [11.85, 12.2],
+        "% Males": [78, 62.9],
+        "Age mean-SD / median-IQR": ["Mean±SD", "Median (IQR)"],
+        "Ethicity ": ["ND", "ND"],
+        "Inflammation excluded by EMB": ["Yes", "No"],
+        "CAD excluded": ["Yes", "Yes"],
+        "Other possible causes of MCI / DCM (drugs, SARS-CoV-2…)": [
+            "Yes (excluded)",
+            "Yes (excluded)",
+        ],
+        "Description of disease comfirmation": [
+            "HF symptoms + Echo + ECG",
+            "Echo + EMB",
+        ],
+        "Method of measurement": ["ELISA", ""],  # second row blank to test null
+        "Cytokine contrentration mean / median": [2.4, 9.5],
+        "Cytokine concentration SD / IQR": [1.6, 12.6],
+        "Cytokine unit": ["pg/mL", "ng/mL"],
+        "Cytokine conecentration mean-SD / median-IQR": [
+            "Mean±SD",
+            "Median (IQR)",
+        ],
+        "NYHA Scale": [0, 0],
+        "LVEF Mean SD / Median SQR": ["Mean±SD", "Median (IQR)"],
+        "LVEF % ": [48.0, 33.0],
+        "LVEDD mean SD / MEDIAN IQR": ["Mean±SD", "Median (IQR)"],
+        "LVEDD SD": ["±3.2", "±4.5"],
+        "EMB performed?": ["No", "Yes"],
+        "EMB Criteria": ["Dallas", "Immunohistochemistry"],
+        "lymphocytes per mm2": [">14", "<7"],
+        "Other EMB Data": ["CD68+", "HLA upregulation"],
+        "Viruses presence": ["Enterovirus", "Parvovirus B19"],
+        "cMRI performed": ["No", "Yes"],
+        "CRP mean-SD / median-IQR": ["Mean±SD", "Median (IQR)"],
+        "CRP": [6.7, 2.25],
+        "CRP unit": ["mg/dL", "mg/L"],
+        "NT-proBNP mean-SD / median-IQR": ["Mean±SD", "Median (IQR)"],
+        "NT-proBNP": [277.0, 2418.0],
+        "NT-proBNP unit": ["pg/mL", "ng/L"],
+        "cTnT mean-SD / median-IQR": ["Mean±SD", "Median (IQR)"],
+        "cTnT": [0.008, 0.09],
+        "cTnT unit": ["ng/mL", "pg/mL"],
+        "cTnI mean-SD / median-IQR": ["Mean±SD", "Median (IQR)"],
+        "cTnI": [0.02, 0.01],
+        "cTnI unit": ["ng/mL", "pg/mL"],
+        "Outcome": ["Mortality", "HF hospitalization"],
+        "Follow-up time (months)": [12.0, 24.0],
+        "Subgroups": ["MCI", "DCM"],
+        "Pathology": ["Myocarditis", "DCM"],
+        "Cohort": ["HF", "MCI"],
+        "Important notes": [
+            "Data extracted from plot using plotdigitizer",
+            "peak values taken",
+        ],
+    }
+    df = pd.DataFrame(data)
+    with pd.ExcelWriter(path) as writer:
+        df.to_excel(writer, sheet_name="Arkusz1", index=False)
+        pd.DataFrame().to_excel(writer, sheet_name="Arkusz2", index=False)
+
+
+def test_parser_handles_types_and_nulls(tmp_path):
+    xlsx_path = tmp_path / "Metaanalysis data.xlsx"
+    _create_sample_xlsx(xlsx_path)
+    records = load_metaanalysis_xlsx(xlsx_path)
+    assert len(records) == 2
+    first, second = records
+
+    assert isinstance(first["Year"], int) and first["Year"] == 2013
+    assert first["Inflammation excluded by EMB"] is True
+    assert second["Inflammation excluded by EMB"] is False
+    # Column headers stripped of whitespace
+    assert "Ethicity" in first and "LVEF %" in first
+    # Empty string converted to None
+    assert second["Method of measurement"] is None
+    # Booleans handled
+    assert first["cMRI performed"] is False and second["cMRI performed"] is True
+    # Floats parsed
+    assert isinstance(second["Follow-up time (months)"], float)


### PR DESCRIPTION
## Summary
- implement `load_metaanalysis_xlsx` to parse `Metaanalysis data.xlsx`
- handle whitespace headers, NaN/empty values, boolean and numeric coercion
- add tests covering type conversions and null handling

## Testing
- `pre-commit run --files app/xlsx_parser.py tests/test_xlsx_parser.py` *(fails: unable to fetch hooks, CONNECT tunnel failed 403)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9199e6d483289cec6771647341ef