### PR TITLE
Add XLSX import persistence to database

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -2,7 +2,7 @@
 
 from flask import jsonify, render_template
 
-from ...models import Study
+from ...models import RawRecord, Study
 
 from . import bp
 
@@ -24,3 +24,11 @@ def studies_list():
     """Display all studies."""
     studies = Study.query.all()
     return render_template("studies/index.html", studies=studies)
+
+
+@bp.get("/raw-records/")
+def raw_records_list():
+    """Display raw imported records with invalid fields highlighted."""
+
+    records = RawRecord.query.all()
+    return render_template("raw_records/index.html", records=records)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 """SQLAlchemy ORM models for meta-analysis database."""
 
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import CheckConstraint, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -154,3 +155,12 @@ class User(db.Model):
     email: Mapped[str] = mapped_column(db.String(255), unique=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(db.String(255), nullable=False)
     role: Mapped[str] = mapped_column(db.String(64), nullable=False, default="user")
+
+
+class RawRecord(db.Model):
+    """Raw row data imported from the metaanalysis XLSX."""
+
+    __tablename__ = "raw_record"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    data: Mapped[dict[str, Any]] = mapped_column(db.JSON, nullable=False)

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -14,6 +14,7 @@
           <a class="nav-link" href="/studies/">Studies</a>
           <a class="nav-link" href="/outcomes/">Outcomes</a>
           <a class="nav-link" href="/effects/">Effects</a>
+          <a class="nav-link" href="/raw-records/">Raw Records</a>
         </div>
       </div>
     </nav>

--- a/app/templates/raw_records/index.html
+++ b/app/templates/raw_records/index.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+{% block title %}Raw Records{% endblock %}
+{% block content %}
+  <h1 class="h3 mb-3">Raw Records</h1>
+  {% for record in records %}
+    {% set invalid = record.data.get('_invalid', []) %}
+    <div class="mb-4">
+      <h2 class="h6">Record {{ record.id }}</h2>
+      <ul class="list-group">
+      {% for key, value in record.data.items() if key != '_invalid' %}
+        <li class="list-group-item{% if key in invalid %} text-danger{% endif %}">
+          <strong>{{ key }}:</strong> {{ value }}
+        </li>
+      {% endfor %}
+      </ul>
+    </div>
+  {% else %}
+    <p class="text-muted">No records.</p>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `RawRecord` model for storing imported XLSX rows
- implement `import_metaanalysis_xlsx` helper to parse and persist data
- flag values that cannot be coerced to expected types and highlight them in a raw record view
- extend tests to verify invalid values are preserved as strings and marked

## Testing
- `ruff check app/xlsx_parser.py app/blueprints/core/routes.py tests/test_xlsx_parser.py`
- `python -m black app/xlsx_parser.py app/blueprints/core/routes.py tests/test_xlsx_parser.py`
- `pytest -q`
- `pre-commit run --files app/xlsx_parser.py app/blueprints/core/routes.py tests/test_xlsx_parser.py` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bda384340c8328bdcbd3fbb2d3f1eb