### PR TITLE
Ensure XLSX import serializes datetimes

### DIFF
--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -25,3 +25,4 @@ def test_cli_import_handles_arkusz1(tmp_path):
         assert result.exit_code == 0
         assert "Loaded sheet 'Arkusz1' with 2 rows" in result.output
         assert RawRecord.query.count() == 2
+        assert RawRecord.query.first().data["Date"] == "2024-01-01T00:00:00"

--- a/tests/test_xlsx_parser.py
+++ b/tests/test_xlsx_parser.py
@@ -24,6 +24,7 @@ def _create_sample_xlsx(path):
             "RCT - mean value after treatment",
             "Observational study",
         ],
+        "Date": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-02-01")],
         "n": [30, 80],
         "Age (mean / median)": [58.4, 51],
         "Age (SD / IQR)": [11.85, 12.2],
@@ -116,6 +117,8 @@ def test_parser_handles_types_and_nulls(tmp_path):
     assert first["cMRI performed"] is False and second["cMRI performed"] is True
     # Floats parsed
     assert isinstance(second["Follow-up time (months)"], float)
+    # Datetimes converted to ISO strings
+    assert first["Date"] == "2024-01-01T00:00:00"
 
 
 def test_import_persists_rows(tmp_path):


### PR DESCRIPTION
## Summary
- Convert datetime values to ISO strings when parsing XLSX rows
- Extend sample data and tests to cover datetime handling during import

## Testing
- `black app/xlsx_parser.py tests/test_cli_import.py tests/test_xlsx_parser.py`
- `ruff check --fix app/xlsx_parser.py tests/test_cli_import.py tests/test_xlsx_parser.py`
- `ruff format app/xlsx_parser.py tests/test_cli_import.py tests/test_xlsx_parser.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdab6dfb6483288ca7f851617496fc