### PR TITLE
Ensure tables exist before importing data

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -167,6 +167,9 @@ def init_app(app) -> None:
     @click.option("--replace", is_flag=True, help="Clear existing data before import")
     def import_xlsx_cmd(path: str, dry_run: bool, replace: bool) -> None:
         """Import data from an XLSX workbook."""
+        # Ensure all tables exist before attempting to import any data
+        db.create_all()
+
         xls = pd.ExcelFile(path)
         click.echo(f"Workbook contains sheets: {', '.join(xls.sheet_names)}")
         # Match sheet names case-insensitively to be tolerant of user provided workbooks
@@ -217,6 +220,9 @@ def init_app(app) -> None:
     @click.option("--replace", is_flag=True, help="Clear existing data before import")
     def import_csv_cmd(folder: str, dry_run: bool, replace: bool) -> None:
         """Import data from a folder of CSV files."""
+        # Ensure tables exist before reading CSV files
+        db.create_all()
+
         folder_path = Path(folder)
         frames: dict[str, pd.DataFrame] = {}
         for sheet in SHEET_MAP:

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -7,7 +7,6 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 
 from app import create_app
-from app.extensions import db
 from app.models import RawRecord
 from test_xlsx_parser import _create_sample_xlsx
 
@@ -20,7 +19,6 @@ def test_cli_import_handles_arkusz1(tmp_path):
     app.config.update(TESTING=True)
     runner = app.test_cli_runner()
     with app.app_context():
-        db.create_all()
         result = runner.invoke(args=["import-xlsx", str(xlsx_path)])
         assert result.exit_code == 0
         assert "Loaded sheet 'Arkusz1' with 2 rows" in result.output


### PR DESCRIPTION
## Summary
- create database tables on import commands so they run on a fresh database
- adjust CLI import test to reflect automatic table creation

## Testing
- `pre-commit run --files app/cli.py tests/test_cli_import.py` *(fails: CalledProcessError: git fetch psf/black: CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdaddb2a6c8328a5106ac37bd3908d