### PR TITLE
Add CLI command to create studies from raw records

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -230,3 +230,39 @@ def init_app(app) -> None:
             if csv_path.exists():
                 frames[sheet] = pd.read_csv(csv_path)
         _import_data(frames, dry_run, replace)
+
+    @app.cli.command("raw-to-studies")
+    @click.option("--replace", is_flag=True, help="Clear existing studies before creation")
+    def raw_to_studies_cmd(replace: bool) -> None:
+        """Create :class:`Study` objects from stored :class:`RawRecord` data."""
+
+        db.create_all()
+        if replace:
+            db.session.query(Study).delete()
+
+        records = RawRecord.query.all()
+        seen: set[str] = set()
+        objects: list[Study] = []
+        for rec in records:
+            data = rec.data
+            title = data.get("ID") or f"{data.get('First author', 'Unknown')} {data.get('Year', '')}".strip()
+            if title in seen or Study.query.filter_by(title=title).first():
+                continue
+            seen.add(title)
+            study = Study(
+                title=title,
+                year=data.get("Year"),
+                country=data.get("Country"),
+                design=data.get("Study type"),
+                authors_text=data.get("First author"),
+                notes=data.get("Important notes"),
+            )
+            objects.append(study)
+
+        if not objects:
+            click.echo("No studies created from raw records.")
+            return
+
+        db.session.add_all(objects)
+        db.session.commit()
+        click.echo(f"Created {len(objects)} studies from raw records.")

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -7,7 +7,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 
 from app import create_app
-from app.models import RawRecord
+from app.models import RawRecord, Study
+from app.extensions import db
 from test_xlsx_parser import _create_sample_xlsx
 
 
@@ -24,3 +25,41 @@ def test_cli_import_handles_arkusz1(tmp_path):
         assert "Loaded sheet 'Arkusz1' with 2 rows" in result.output
         assert RawRecord.query.count() == 2
         assert RawRecord.query.first().data["Date"] == "2024-01-01T00:00:00"
+
+
+def test_cli_creates_studies_from_raw_records(tmp_path):
+    xlsx_path = tmp_path / "Metaanalysis data.xlsx"
+    _create_sample_xlsx(xlsx_path)
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    runner = app.test_cli_runner()
+    with app.app_context():
+        runner.invoke(args=["import-xlsx", str(xlsx_path)])
+        result = runner.invoke(args=["raw-to-studies"])
+        assert result.exit_code == 0
+        assert Study.query.count() == 2
+        study = Study.query.filter_by(title="M00022").first()
+        assert study.authors_text == "Bielecka-Dabrowa"
+        assert study.year == 2013
+        assert study.country == "Poland"
+        assert study.design == "RCT - mean value after treatment"
+
+
+def test_cli_deduplicates_raw_records(tmp_path):
+    xlsx_path = tmp_path / "Metaanalysis data.xlsx"
+    _create_sample_xlsx(xlsx_path)
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    runner = app.test_cli_runner()
+    with app.app_context():
+        runner.invoke(args=["import-xlsx", str(xlsx_path)])
+        # Add a duplicate raw record
+        first = RawRecord.query.first()
+        db.session.add(RawRecord(data=first.data))
+        db.session.commit()
+        assert RawRecord.query.count() == 3
+        result = runner.invoke(args=["raw-to-studies"])
+        assert result.exit_code == 0
+        assert Study.query.count() == 2


### PR DESCRIPTION
## Summary
- add `raw-to-studies` CLI command to generate Study entries from existing RawRecord data
- ensure duplicate RawRecords do not create duplicate studies
- test CLI to ensure studies are created with expected fields and duplicates are ignored

## Testing
- `pre-commit run --files app/cli.py tests/test_cli_import.py` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdaf924f848328ad69186de21a4ef5