### PR TITLE
Set site titles to 'Metaanalaysis cytokines'

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}met analiza cytokiny{% endblock %}
+{% block title %}Metaanalaysis cytokines{% endblock %}
 {% block content %}
   <div class="d-flex align-items-center justify-content-between">
     <h1 class="h3 mb-3">Witaj w aplikacji metaanalizy</h1>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{% block title %}met analiza cytokiny{% endblock %}</title>
+    <title>{% block title %}Metaanalaysis cytokines{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom mb-3">
       <div class="container">
-        <a class="navbar-brand" href="/">Meta</a>
+        <a class="navbar-brand" href="/">Metaanalaysis cytokines</a>
         <div class="navbar-nav">
           <a class="nav-link" href="/studies/">Studies</a>
           <a class="nav-link" href="/outcomes/">Outcomes</a>

--- a/app/templates/raw_records/index.html
+++ b/app/templates/raw_records/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}Raw Records{% endblock %}
+{% block title %}Metaanalaysis cytokines{% endblock %}
 {% block content %}
   <h1 class="h3 mb-3">Raw Records</h1>
   {% for record in records %}

--- a/app/templates/studies/index.html
+++ b/app/templates/studies/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block title %}met analiza cytokiny{% endblock %}
+{% block title %}Metaanalaysis cytokines{% endblock %}
 {% block content %}
   <h1 class="h3 mb-3">Badania</h1>
   <ul class="list-group">


### PR DESCRIPTION
## Summary
- Update page template to use "Metaanalaysis cytokines" for the browser tab title and navbar brand
- Apply same title across the index, studies, and raw records templates

## Testing
- `pre-commit run --files app/templates/layout.html app/templates/index.html app/templates/raw_records/index.html app/templates/studies/index.html` *(fails: unable to access https://github.com/psf/black/)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6a4fcbc8328919a270a08404fb8