### PR TITLE
Display author and year for each study UID

### DIFF
--- a/app/templates/studies/index.html
+++ b/app/templates/studies/index.html
@@ -5,7 +5,7 @@
   <ul class="list-group">
   {% for study in studies %}
     <li class="list-group-item">
-      {{ study.title }}{% if study.year %} ({{ study.year }}){% endif %}
+      {{ study.title }} - {{ study.authors_text }} et al.{% if study.year %} ({{ study.year }}){% endif %}
     </li>
   {% else %}
     <li class="list-group-item text-muted">Brak badań</li>


### PR DESCRIPTION
## Summary
- show first author surname with `et al.` and year alongside each study's UID in the studies list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6bd1f648328a753ca479009754d