### PR TITLE
Add study group creation CLI

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ class Study(db.Model):
     outcomes: Mapped[list["Outcome"]] = relationship(back_populates="study")
     effects: Mapped[list["Effect"]] = relationship(back_populates="study")
     covariates: Mapped[list["Covariate"]] = relationship(back_populates="study")
+    groups: Mapped[list["StudyGroup"]] = relationship(back_populates="study")
     tags: Mapped[list["Tag"]] = relationship(
         secondary="study_tag", back_populates="studies"
     )
@@ -124,6 +125,18 @@ class Covariate(db.Model):
     value: Mapped[str | None] = mapped_column(db.String(255))
 
     study: Mapped[Study] = relationship(back_populates="covariates")
+
+
+class StudyGroup(db.Model):
+    """Unique population within a study."""
+
+    __tablename__ = "study_group"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"), index=True)
+    data: Mapped[dict[str, Any]] = mapped_column(db.JSON, nullable=False)
+
+    study: Mapped[Study] = relationship(back_populates="groups")
 
 
 study_tag = db.Table(

--- a/tests/test_cli_groups.py
+++ b/tests/test_cli_groups.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+from app import create_app
+from app.extensions import db
+from app.models import RawRecord, Study, StudyGroup
+from test_xlsx_parser import _create_sample_xlsx
+
+
+def test_cli_creates_study_groups(tmp_path):
+    xlsx_path = tmp_path / "Metaanalysis data.xlsx"
+    _create_sample_xlsx(xlsx_path)
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    runner = app.test_cli_runner()
+
+    with app.app_context():
+        runner.invoke(args=["import-xlsx", str(xlsx_path)])
+        runner.invoke(args=["raw-to-studies"])
+
+        first = RawRecord.query.first()
+        data2 = dict(first.data)
+        data2["n"] = 15
+        db.session.add(RawRecord(data=data2))
+        db.session.commit()
+
+        result = runner.invoke(args=["raw-to-groups"])
+        assert result.exit_code == 0
+        assert StudyGroup.query.count() == 3
+        study = Study.query.filter_by(title="M00022").first()
+        assert len(study.groups) == 2


### PR DESCRIPTION
## Summary
- add StudyGroup model and relation on Study
- implement `raw-to-groups` CLI to deduplicate populations using key demographic fields
- test study group creation from raw records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7870ac483288f517c593e84bf8f