### PR TITLE
Display study groups under gray headings

### DIFF
--- a/app/templates/studies/index.html
+++ b/app/templates/studies/index.html
@@ -5,7 +5,18 @@
   <ul class="list-group">
   {% for study in studies %}
     <li class="list-group-item">
-      {{ study.title }} - {{ study.authors_text }} et al.{% if study.year %} ({{ study.year }}){% endif %}
+      <div class="bg-light fw-bold p-2">
+        {{ study.title }} - {{ study.authors_text }} et al.{% if study.year %} ({{ study.year }}){% endif %}
+      </div>
+      {% if study.groups %}
+        <ul class="mt-2 mb-0">
+        {% for group in study.groups %}
+          <li>{{ group.data.get('Group description (MCI / DCM / Healthy / …)') or 'Brak opisu' }}</li>
+        {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-muted mb-0 mt-2">Brak zidentyfikowanych grup</p>
+      {% endif %}
     </li>
   {% else %}
     <li class="list-group-item text-muted">Brak badań</li>


### PR DESCRIPTION
## Summary
- Style study entries so the title is bold on a gray background
- List any identified groups beneath each study or show a fallback message

## Testing
- `pre-commit run --files app/templates/studies/index.html` (fails: unable to access GitHub)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb98c69248328a9d81d8715259d29