### PR TITLE
Add form and route to create studies

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -1,8 +1,10 @@
 """Core routes for the application."""
 
-from flask import jsonify, render_template
+from flask import flash, jsonify, redirect, render_template, url_for
 
+from ... import db
 from ...models import RawRecord, Study
+from ...forms import StudyForm
 
 from . import bp
 
@@ -24,6 +26,25 @@ def studies_list():
     """Display all studies."""
     studies = Study.query.all()
     return render_template("studies/index.html", studies=studies)
+
+
+@bp.route("/studies/new", methods=["GET", "POST"])
+def studies_create():
+    """Create a new study."""
+    form = StudyForm()
+    if form.validate_on_submit():
+        study = Study(
+            id=form.id.data,
+            authors_text=form.author.data,
+            year=form.year.data,
+            country=form.country.data,
+            title=form.title.data or "Untitled",
+        )
+        db.session.add(study)
+        db.session.commit()
+        flash("Dodano badanie", "success")
+        return redirect(url_for("core.studies_list"))
+    return render_template("studies/new.html", form=form)
 
 
 @bp.get("/raw-records/")

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,15 @@
+"""Form definitions for the application."""
+
+from flask_wtf import FlaskForm
+from wtforms import IntegerField, StringField
+from wtforms.validators import DataRequired
+
+
+class StudyForm(FlaskForm):
+    """Form for creating a new study."""
+
+    id = IntegerField("ID", validators=[DataRequired()])
+    author = StringField("Autor", validators=[DataRequired()])
+    year = IntegerField("Rok", validators=[DataRequired()])
+    country = StringField("Kraj", validators=[DataRequired()])
+    title = StringField("Tytuł")

--- a/app/templates/studies/index.html
+++ b/app/templates/studies/index.html
@@ -2,6 +2,7 @@
 {% block title %}Metaanalaysis cytokines{% endblock %}
 {% block content %}
   <h1 class="h3 mb-3">Badania</h1>
+  <a class="btn btn-primary mb-3" href="/studies/new">Dodaj badanie</a>
   <ul class="list-group">
   {% for study in studies %}
     <li class="list-group-item">

--- a/app/templates/studies/new.html
+++ b/app/templates/studies/new.html
@@ -1,0 +1,15 @@
+{% extends "layout.html" %}
+{% from "macros/forms.html" import render_field %}
+{% block title %}Nowe badanie{% endblock %}
+{% block content %}
+  <h1 class="h3 mb-3">Nowe badanie</h1>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    {{ render_field(form.id) }}
+    {{ render_field(form.author) }}
+    {{ render_field(form.year) }}
+    {{ render_field(form.country) }}
+    {{ render_field(form.title) }}
+    <button class="btn btn-primary" type="submit">Zapisz</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow creating new studies with required ID, author, year and country fields
- add dedicated form template and link from study list
- wire up database persistence and feedback

## Testing
- `pre-commit run --files app/forms.py app/blueprints/core/routes.py app/templates/studies/index.html app/templates/studies/new.html` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*
- `black app/forms.py app/blueprints/core/routes.py`
- `ruff check app/forms.py app/blueprints/core/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdb9d88c9883288665e227b70e2953