### PR TITLE
Add study group detail view

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -3,7 +3,7 @@
 from flask import flash, jsonify, redirect, render_template, url_for
 
 from ... import db
-from ...models import RawRecord, Study
+from ...models import RawRecord, Study, StudyGroup
 from ...forms import StudyForm
 
 from . import bp
@@ -53,3 +53,10 @@ def raw_records_list():
 
     records = RawRecord.query.all()
     return render_template("raw_records/index.html", records=records)
+
+
+@bp.get("/studies/<int:study_id>/groups/<int:group_id>")
+def study_group_detail(study_id: int, group_id: int):
+    """Display details for a single study group."""
+    group = StudyGroup.query.filter_by(id=group_id, study_id=study_id).first_or_404()
+    return render_template("study_groups/detail.html", group=group)

--- a/app/templates/studies/index.html
+++ b/app/templates/studies/index.html
@@ -12,7 +12,11 @@
       {% if study.groups %}
         <ul class="mt-2 mb-0">
         {% for group in study.groups %}
-          <li>{{ group.data.get('Group description (MCI / DCM / Healthy / …)') or 'Brak opisu' }}</li>
+          <li>
+            <a href="{{ url_for('core.study_group_detail', study_id=study.id, group_id=group.id) }}">
+              {{ group.data.get('Group description (MCI / DCM / Healthy / …)') or 'Brak opisu' }}
+            </a>
+          </li>
         {% endfor %}
         </ul>
       {% else %}

--- a/app/templates/study_groups/detail.html
+++ b/app/templates/study_groups/detail.html
@@ -1,0 +1,16 @@
+{% extends "layout.html" %}
+{% block title %}Szczegóły grupy{% endblock %}
+{% block content %}
+  <h1 class="h3 mb-3">Szczegóły grupy</h1>
+  <table class="table">
+    <tbody>
+    {% for key, value in group.data.items() %}
+      <tr>
+        <th scope="row">{{ key }}</th>
+        <td>{{ value }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('core.studies_list') }}" class="btn btn-secondary">Powrót</a>
+{% endblock %}

--- a/tests/test_study_group_detail.py
+++ b/tests/test_study_group_detail.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+from app import create_app
+from app.extensions import db
+from app.models import Study, StudyGroup
+
+
+def test_study_group_detail_route():
+    app = create_app()
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.create_all()
+        study = Study(title="Test study")
+        db.session.add(study)
+        db.session.commit()
+        group = StudyGroup(
+            study_id=study.id,
+            data={"Group description (MCI / DCM / Healthy / …)": "Group A", "n": 10},
+        )
+        db.session.add(group)
+        db.session.commit()
+        client = app.test_client()
+        resp = client.get(f"/studies/{study.id}/groups/{group.id}")
+        assert resp.status_code == 200
+        assert b"Group A" in resp.data
+        assert b"n" in resp.data
+        assert b"10" in resp.data


### PR DESCRIPTION
## Summary
- add route to display study group details
- link study groups from study list to detail view
- test study group detail route

## Testing
- `pre-commit run --files app/blueprints/core/routes.py tests/test_study_group_detail.py` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*
- `black app/blueprints/core/routes.py tests/test_study_group_detail.py`
- `ruff check app/blueprints/core/routes.py tests/test_study_group_detail.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc0377f88328a682ac5f0a3a4cda