### PR TITLE
Add primary cytokine outcome export to study groups

### DIFF
--- a/tests/test_cli_groups.py
+++ b/tests/test_cli_groups.py
@@ -35,3 +35,13 @@ def test_cli_creates_study_groups(tmp_path):
         assert StudyGroup.query.count() == 3
         study = Study.query.filter_by(title="M00022").first()
         assert len(study.groups) == 2
+
+        # verify primary outcome data attached to groups
+        po = study.groups[0].data["primary_outcome"]
+        assert po["name"] == "IL6"
+        assert po["value"] == 2.4
+        assert po["value_type"] == "mean"
+        assert po["dispersion"] == 1.6
+        assert po["dispersion_type"] == "sd"
+        assert po["unit"] == "pg/mL"
+        assert po["method"] == "ELISA"

--- a/tests/test_xlsx_parser.py
+++ b/tests/test_xlsx_parser.py
@@ -41,6 +41,7 @@ def _create_sample_xlsx(path):
             "HF symptoms + Echo + ECG",
             "Echo + EMB",
         ],
+        "Cytokine": ["IL6", "TNF-alpha"],
         "Method of measurement": ["ELISA", ""],  # second row blank to test null
         "Cytokine contrentration mean / median": [2.4, 9.5],
         "Cytokine concentration SD / IQR": [1.6, 12.6],
@@ -107,6 +108,7 @@ def test_parser_handles_types_and_nulls(tmp_path):
     first, second = records
 
     assert isinstance(first["Year"], int) and first["Year"] == 2013
+    assert first["Cytokine"] == "IL6"
     assert first["Inflammation excluded by EMB"] is True
     assert second["Inflammation excluded by EMB"] is False
     # Column headers stripped of whitespace


### PR DESCRIPTION
## Summary
- Capture cytokine concentration details as the primary outcome when creating study groups
- Parse measurement descriptors to classify mean/median and dispersion types
- Test that study groups expose cytokine outcome data and update sample XLSX fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd1935e483288cebed9666cb3a89