### PR TITLE
Handle missing outcome method column

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable
 
 import click
 import pandas as pd
+from sqlalchemy import inspect, text
 
 from .extensions import db
 from .models import (
@@ -353,6 +354,11 @@ def init_app(app) -> None:
         """Create :class:`StudyGroup` objects from raw records."""
 
         db.create_all()
+        inspector = inspect(db.engine)
+        outcome_cols = [col["name"] for col in inspector.get_columns("outcome")]
+        if "method" not in outcome_cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE outcome ADD COLUMN method VARCHAR(255)"))
         if replace:
             db.session.query(StudyGroup).delete()
 

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -29,6 +29,7 @@ This document lists the database tables and their fields.
 - **unit** (`String`): Measurement unit.
 - **direction** (`String`): Direction of effect.
 - **domain** (`String`): Outcome domain.
+- **method** (`String`): Measurement technique.
 
 ## Effect
 - **id** (`Integer`): Primary key.


### PR DESCRIPTION
## Summary
- ensure `raw-to-groups` adds missing `method` column to `outcome`
- document the `method` field in the data dictionary

## Testing
- `pytest`
- `pre-commit run --files app/cli.py docs/data_dictionary.md` *(fails: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0f3e3a08328ae2d559a1f0cfbf8