### PR TITLE
Handle numeric ranges with commas in group import

### DIFF
--- a/tests/test_cli_groups.py
+++ b/tests/test_cli_groups.py
@@ -27,6 +27,8 @@ def test_cli_creates_study_groups(tmp_path):
         first = RawRecord.query.first()
         data2 = dict(first.data)
         data2["n"] = 15
+        data2["Cytokine contrentration mean / median"] = "5,1"
+        data2["Cytokine concentration SD / IQR"] = "0,49-28,50"
         db.session.add(RawRecord(data=data2))
         db.session.commit()
 
@@ -45,3 +47,8 @@ def test_cli_creates_study_groups(tmp_path):
         assert group.primary_outcome_dispersion_type == "sd"
         assert group.primary_outcome.unit == "pg/mL"
         assert group.primary_outcome.method == "ELISA"
+
+        # second group values parsed from comma/range formatted strings
+        group2 = StudyGroup.query.filter_by(study_id=study.id, n=15).first()
+        assert group2.primary_outcome_value == 5.1
+        assert group2.primary_outcome_dispersion == 28.5


### PR DESCRIPTION
## Summary
- parse float values with commas or ranges when importing study groups
- test parsing of comma and range formatted numeric strings

## Testing
- `pytest`
- `pre-commit run --files app/cli.py tests/test_cli_groups.py` *(fails: unable to access 'https://github.com/psf/black/' : CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc26bc6a08328b2eb56dc39d190c3