### PR TITLE
Store group outcome values with outcomes

### DIFF
--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -55,6 +55,31 @@ This document lists the database tables and their fields.
 - **name** (`String`): Covariate name.
 - **value** (`String`): Covariate value.
 
+## StudyGroup
+- **id** (`Integer`): Primary key.
+- **study_id** (`Integer`, FK): Related study.
+- **n** (`Integer`): Sample size.
+- **age_mean_median** (`String`): Age (mean or median).
+- **age_sd_iqr** (`String`): Age dispersion (SD or IQR).
+- **age_mean_sd_median_iqr** (`String`): Combined age descriptor.
+- **percent_males** (`Float`): Percentage of males.
+- **ethnicity** (`String`): Ethnicity.
+- **description** (`String`): Group description.
+- **other_info** (`String`): Additional information.
+- **inflammation_excluded_by_emb** (`String`): Inflammation exclusion method.
+- **cad_excluded** (`String`): CAD excluded.
+- **other_causes** (`String`): Other possible causes.
+- **disease_confirmation** (`String`): Disease confirmation description.
+
+## GroupOutcome
+- **id** (`Integer`): Primary key.
+- **group_id** (`Integer`, FK): Related study group.
+- **outcome_id** (`Integer`, FK): Related outcome.
+- **value** (`Float`): Measured value.
+- **value_type** (`String`): Central tendency type.
+- **dispersion** (`Float`): Dispersion value.
+- **dispersion_type** (`String`): Dispersion type.
+
 ## Tag
 - **id** (`Integer`): Primary key.
 - **name** (`String`, unique): Tag name.

--- a/tests/test_cli_groups.py
+++ b/tests/test_cli_groups.py
@@ -38,17 +38,19 @@ def test_cli_creates_study_groups(tmp_path):
         study = Study.query.filter_by(title="M00022").first()
         assert len(study.groups) == 2
 
-        # verify primary outcome data attached to groups
+        # verify outcome data attached to groups
         group = study.groups[0]
-        assert group.primary_outcome.name == "IL6"
-        assert group.primary_outcome_value == 2.4
-        assert group.primary_outcome_value_type == "mean"
-        assert group.primary_outcome_dispersion == 1.6
-        assert group.primary_outcome_dispersion_type == "sd"
-        assert group.primary_outcome.unit == "pg/mL"
-        assert group.primary_outcome.method == "ELISA"
+        go = group.outcomes[0]
+        assert go.outcome.name == "IL6"
+        assert go.value == 2.4
+        assert go.value_type == "mean"
+        assert go.dispersion == 1.6
+        assert go.dispersion_type == "sd"
+        assert go.outcome.unit == "pg/mL"
+        assert go.outcome.method == "ELISA"
 
         # second group values parsed from comma/range formatted strings
         group2 = StudyGroup.query.filter_by(study_id=study.id, n=15).first()
-        assert group2.primary_outcome_value == 5.1
-        assert group2.primary_outcome_dispersion == 28.5
+        go2 = group2.outcomes[0]
+        assert go2.value == 5.1
+        assert go2.dispersion == 28.5


### PR DESCRIPTION
## Summary
- introduce `GroupOutcome` model to attach measurements directly to outcomes
- remove primary outcome fields from study groups and relate them via `GroupOutcome`
- adjust CLI import logic and tests for new group outcome storage
- document new tables in data dictionary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3e840448328a2b2f8cc2d5d65db