### PR TITLE
Simplify StudyGroup model and extend GroupOutcome

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -36,17 +36,7 @@ SHEET_MAP: dict[str, tuple[type, list[str]]] = {
 
 GROUP_FIELDS: list[str] = [
     "n",
-    "Age (mean / median)",
-    "Age (SD / IQR)",
-    "Age mean-SD / median-IQR",
-    "% Males",
-    "Ethicity",
     "Group description (MCI / DCM / Healthy / …)",
-    "Other important group infomation",
-    "Inflammation excluded by EMB",
-    "CAD excluded",
-    "Other possible causes of MCI / DCM (drugs, SARS-CoV-2…)",
-    "Description of disease comfirmation",
 ]
 
 
@@ -407,24 +397,8 @@ def init_app(app) -> None:
             group = StudyGroup(
                 study_id=study.id,
                 n=group_vals.get("n"),
-                age_mean_median=group_vals.get("Age (mean / median)"),
-                age_sd_iqr=group_vals.get("Age (SD / IQR)"),
-                age_mean_sd_median_iqr=group_vals.get("Age mean-SD / median-IQR"),
-                percent_males=group_vals.get("% Males"),
-                ethnicity=group_vals.get("Ethicity"),
                 description=group_vals.get(
                     "Group description (MCI / DCM / Healthy / …)"
-                ),
-                other_info=group_vals.get("Other important group infomation"),
-                inflammation_excluded_by_emb=group_vals.get(
-                    "Inflammation excluded by EMB"
-                ),
-                cad_excluded=group_vals.get("CAD excluded"),
-                other_causes=group_vals.get(
-                    "Other possible causes of MCI / DCM (drugs, SARS-CoV-2…)"
-                ),
-                disease_confirmation=group_vals.get(
-                    "Description of disease comfirmation"
                 ),
             )
             db.session.add(group)
@@ -442,6 +416,8 @@ def init_app(app) -> None:
                         data.get("Cytokine concentration SD / IQR"), take="last"
                     ),
                     dispersion_type=dispersion,
+                    unit=po_unit,
+                    data_type=None,
                 )
             )
             created += 1

--- a/app/models.py
+++ b/app/models.py
@@ -139,17 +139,7 @@ class StudyGroup(db.Model):
     id: Mapped[int] = mapped_column(primary_key=True)
     study_id: Mapped[int] = mapped_column(db.ForeignKey("study.id"), index=True)
     n: Mapped[int | None] = mapped_column(db.Integer)
-    age_mean_median: Mapped[str | None] = mapped_column(db.String(255))
-    age_sd_iqr: Mapped[str | None] = mapped_column(db.String(255))
-    age_mean_sd_median_iqr: Mapped[str | None] = mapped_column(db.String(255))
-    percent_males: Mapped[float | None] = mapped_column(db.Float)
-    ethnicity: Mapped[str | None] = mapped_column(db.String(255))
     description: Mapped[str | None] = mapped_column(db.String(255))
-    other_info: Mapped[str | None] = mapped_column(db.String(255))
-    inflammation_excluded_by_emb: Mapped[str | None] = mapped_column(db.String(255))
-    cad_excluded: Mapped[str | None] = mapped_column(db.String(255))
-    other_causes: Mapped[str | None] = mapped_column(db.String(255))
-    disease_confirmation: Mapped[str | None] = mapped_column(db.String(255))
 
     study: Mapped[Study] = relationship(back_populates="groups")
     outcomes: Mapped[list["GroupOutcome"]] = relationship(back_populates="group")
@@ -159,17 +149,7 @@ class StudyGroup(db.Model):
         """Return a dict representation similar to the old JSON column."""
         return {
             "n": self.n,
-            "Age (mean / median)": self.age_mean_median,
-            "Age (SD / IQR)": self.age_sd_iqr,
-            "Age mean-SD / median-IQR": self.age_mean_sd_median_iqr,
-            "% Males": self.percent_males,
-            "Ethicity": self.ethnicity,
             "Group description (MCI / DCM / Healthy / …)": self.description,
-            "Other important group infomation": self.other_info,
-            "Inflammation excluded by EMB": self.inflammation_excluded_by_emb,
-            "CAD excluded": self.cad_excluded,
-            "Other possible causes of MCI / DCM (drugs, SARS-CoV-2…)": self.other_causes,
-            "Description of disease comfirmation": self.disease_confirmation,
             "outcomes": [
                 {
                     "name": go.outcome.name if go.outcome else None,
@@ -177,7 +157,8 @@ class StudyGroup(db.Model):
                     "value_type": go.value_type,
                     "dispersion": go.dispersion,
                     "dispersion_type": go.dispersion_type,
-                    "unit": go.outcome.unit if go.outcome else None,
+                    "data_type": go.data_type,
+                    "unit": go.unit,
                     "method": go.outcome.method if go.outcome else None,
                 }
                 for go in self.outcomes
@@ -197,6 +178,8 @@ class GroupOutcome(db.Model):
     value_type: Mapped[str | None] = mapped_column(db.String(16))
     dispersion: Mapped[float | None] = mapped_column(db.Float)
     dispersion_type: Mapped[str | None] = mapped_column(db.String(16))
+    data_type: Mapped[str | None] = mapped_column(db.String(16))
+    unit: Mapped[str | None] = mapped_column(db.String(64))
 
     group: Mapped[StudyGroup] = relationship(back_populates="outcomes")
     outcome: Mapped[Outcome] = relationship(back_populates="group_results")

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -59,17 +59,7 @@ This document lists the database tables and their fields.
 - **id** (`Integer`): Primary key.
 - **study_id** (`Integer`, FK): Related study.
 - **n** (`Integer`): Sample size.
-- **age_mean_median** (`String`): Age (mean or median).
-- **age_sd_iqr** (`String`): Age dispersion (SD or IQR).
-- **age_mean_sd_median_iqr** (`String`): Combined age descriptor.
-- **percent_males** (`Float`): Percentage of males.
-- **ethnicity** (`String`): Ethnicity.
 - **description** (`String`): Group description.
-- **other_info** (`String`): Additional information.
-- **inflammation_excluded_by_emb** (`String`): Inflammation exclusion method.
-- **cad_excluded** (`String`): CAD excluded.
-- **other_causes** (`String`): Other possible causes.
-- **disease_confirmation** (`String`): Disease confirmation description.
 
 ## GroupOutcome
 - **id** (`Integer`): Primary key.
@@ -79,6 +69,8 @@ This document lists the database tables and their fields.
 - **value_type** (`String`): Central tendency type.
 - **dispersion** (`Float`): Dispersion value.
 - **dispersion_type** (`String`): Dispersion type.
+- **data_type** (`String`): Type of data.
+- **unit** (`String`): Measurement unit.
 
 ## Tag
 - **id** (`Integer`): Primary key.

--- a/migrations/versions/0002_group_outcome_unit_data_type.py
+++ b/migrations/versions/0002_group_outcome_unit_data_type.py
@@ -1,0 +1,77 @@
+"""Add data_type and unit to group_outcome; trim study_group columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0002_group_outcome_unit_data_type"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column(
+        "group_outcome",
+        sa.Column("data_type", sa.String(length=16), nullable=True),
+    )
+    op.add_column(
+        "group_outcome",
+        sa.Column("unit", sa.String(length=64), nullable=True),
+    )
+    op.drop_column("study_group", "age_mean_median")
+    op.drop_column("study_group", "age_sd_iqr")
+    op.drop_column("study_group", "age_mean_sd_median_iqr")
+    op.drop_column("study_group", "percent_males")
+    op.drop_column("study_group", "ethnicity")
+    op.drop_column("study_group", "other_info")
+    op.drop_column("study_group", "inflammation_excluded_by_emb")
+    op.drop_column("study_group", "cad_excluded")
+    op.drop_column("study_group", "other_causes")
+    op.drop_column("study_group", "disease_confirmation")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "study_group",
+        sa.Column("disease_confirmation", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("other_causes", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("cad_excluded", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column(
+            "inflammation_excluded_by_emb", sa.String(length=255), nullable=True
+        ),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("other_info", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("ethnicity", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("percent_males", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("age_mean_sd_median_iqr", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("age_sd_iqr", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "study_group",
+        sa.Column("age_mean_median", sa.String(length=255), nullable=True),
+    )
+    op.drop_column("group_outcome", "unit")
+    op.drop_column("group_outcome", "data_type")

--- a/tests/test_cli_groups.py
+++ b/tests/test_cli_groups.py
@@ -47,6 +47,7 @@ def test_cli_creates_study_groups(tmp_path):
         assert go.dispersion == 1.6
         assert go.dispersion_type == "sd"
         assert go.outcome.unit == "pg/mL"
+        assert go.unit == "pg/mL"
         assert go.outcome.method == "ELISA"
 
         # second group values parsed from comma/range formatted strings


### PR DESCRIPTION
## Summary
- drop demographic columns from StudyGroup and expose only size and description
- store unit and data_type directly on GroupOutcome and wire up importer
- document new schema and add migration

## Testing
- `pytest`
- `pre-commit run --files app/cli.py app/models.py docs/data_dictionary.md tests/test_cli_groups.py migrations/versions/0002_group_outcome_unit_data_type.py` *(fails: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5dd6d2083289c050b100ecc73db