### PR TITLE
Add studies database table and listing page

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -2,6 +2,8 @@
 
 from flask import jsonify, render_template
 
+from app.models import Study
+
 from . import bp
 
 
@@ -15,3 +17,10 @@ def healthz():
 def index():
     """Application root."""
     return render_template("index.html")
+
+
+@bp.get("/studies")
+def studies():
+    """List available studies."""
+    all_studies = Study.query.order_by(Study.publication_year.desc()).all()
+    return render_template("studies.html", studies=all_studies)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,19 @@
+"""Database models for the application."""
+
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class Study(db.Model):
+    """Research study metadata."""
+
+    __tablename__ = "studies"
+
+    study_id = db.Column(db.String, primary_key=True)
+    first_author = db.Column(db.String, nullable=False)
+    publication_year = db.Column(db.Integer)
+    country = db.Column(db.String)
+    study_design = db.Column(db.String)
+    notes = db.Column(db.Text)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,5 +4,5 @@
   <div class="d-flex align-items-center justify-content-between">
     <h1 class="h3 mb-3">Witaj w aplikacji metaanalizy</h1>
   </div>
-  <p class="text-secondary">Funkcje bazy danych zostały tymczasowo usunięte.</p>
+  <p class="text-secondary">Przejdź do zakładki <a href="{{ url_for('core.studies') }}">Studies</a>, aby zobaczyć badania.</p>
 {% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -10,7 +10,9 @@
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom mb-3">
       <div class="container">
         <a class="navbar-brand" href="/">Metaanalaysis cytokines</a>
-        <div class="navbar-nav"></div>
+        <div class="navbar-nav">
+          <a class="nav-link" href="{{ url_for('core.studies') }}">Studies</a>
+        </div>
       </div>
     </nav>
 

--- a/app/templates/studies.html
+++ b/app/templates/studies.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{% block title %}Studies{% endblock %}
+{% block content %}
+  <div class="d-flex align-items-center justify-content-between">
+    <h1 class="h3 mb-3">Studies</h1>
+  </div>
+  {% if studies %}
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">ID</th>
+          <th scope="col">First author</th>
+          <th scope="col">Year</th>
+          <th scope="col">Country</th>
+          <th scope="col">Study type</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for study in studies %}
+          <tr>
+            <td>{{ study.study_id }}</td>
+            <td>{{ study.first_author }}</td>
+            <td>{{ study.publication_year }}</td>
+            <td>{{ study.country }}</td>
+            <td>{{ study.study_design }}</td>
+            <td>{{ study.notes }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="text-secondary">No studies found.</p>
+  {% endif %}
+{% endblock %}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core app
 Flask>=3.0.0,<4
+Flask-SQLAlchemy>=3.1
 python-dotenv>=1.0
 
 # Dev tooling


### PR DESCRIPTION
## Summary
- integrate Flask-SQLAlchemy with SQLite database
- add `Study` model and `/studies` listing page
- link studies page in navigation

## Testing
- `black app/__init__.py app/blueprints/core/routes.py app/models.py`
- `ruff check .`
- `pytest -q`
- `make install` *(fails: Could not find a version that satisfies the requirement Flask<4,>=3.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcf1c9540832891e16a69c5bb883e