### PR TITLE
Add numeric primary key to Study

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -11,7 +11,8 @@ class Study(db.Model):
 
     __tablename__ = "studies"
 
-    study_id = db.Column(db.String, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
+    study_id = db.Column(db.String, unique=True, nullable=False)
     first_author = db.Column(db.String, nullable=False)
     publication_year = db.Column(db.Integer)
     country = db.Column(db.String)

--- a/app/templates/studies.html
+++ b/app/templates/studies.html
@@ -9,6 +9,7 @@
       <thead>
         <tr>
           <th scope="col">ID</th>
+          <th scope="col">Study ID</th>
           <th scope="col">First author</th>
           <th scope="col">Year</th>
           <th scope="col">Country</th>
@@ -19,6 +20,7 @@
       <tbody>
         {% for study in studies %}
           <tr>
+            <td>{{ study.id }}</td>
             <td>{{ study.study_id }}</td>
             <td>{{ study.first_author }}</td>
             <td>{{ study.publication_year }}</td>


### PR DESCRIPTION
## Summary
- add auto-incrementing `id` field to `Study` model
- show both internal `id` and user-facing `study_id` on studies page

## Testing
- `pre-commit run --files app/models.py app/templates/studies.html` *(fails: unable to access https://github.com/psf/black/)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdd65d96308328b0d01ce6f4e0f6f6