### PR TITLE
Add CSV import page for studies and cohorts

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -1,8 +1,21 @@
 """Core routes for the application."""
 
-from flask import jsonify, render_template
+from flask import (
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+import os
+import tempfile
 
-from app.models import Study
+from app.models import (
+    Study,
+    import_cohorts_from_csv,
+    import_studies_from_csv,
+)
 
 from . import bp
 
@@ -24,3 +37,31 @@ def studies():
     """List available studies."""
     all_studies = Study.query.order_by(Study.publication_year.desc()).all()
     return render_template("studies.html", studies=all_studies)
+
+
+@bp.route("/import", methods=["GET", "POST"])
+def import_data():
+    """Import studies or cohorts from a CSV file."""
+    if request.method == "POST":
+        data_type = request.form.get("data_type")
+        uploaded = request.files.get("file")
+        if not uploaded or data_type not in {"studies", "cohorts"}:
+            flash("Invalid upload", "danger")
+            return redirect(url_for("core.import_data"))
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            uploaded.save(tmp.name)
+            tmp_path = tmp.name
+        try:
+            if data_type == "studies":
+                created = import_studies_from_csv(tmp_path)
+                flash(f"Imported {len(created)} studies", "success")
+            else:
+                created = import_cohorts_from_csv(tmp_path)
+                flash(f"Imported {len(created)} cohorts", "success")
+        finally:
+            os.unlink(tmp_path)
+
+        return redirect(url_for("core.import_data"))
+
+    return render_template("import.html")

--- a/app/templates/import.html
+++ b/app/templates/import.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+{% block title %}Import{% endblock %}
+{% block content %}
+  <h1 class="h3 mb-3">Import Data</h1>
+  <div class="row">
+    <div class="col-md-6">
+      <h2 class="h5">Studies</h2>
+      <form method="post" enctype="multipart/form-data" class="mb-3">
+        <input type="hidden" name="data_type" value="studies" />
+        <div class="mb-3">
+          <input class="form-control" type="file" name="file" accept=".csv" required />
+        </div>
+        <button class="btn btn-primary" type="submit">Import</button>
+      </form>
+    </div>
+    <div class="col-md-6">
+      <h2 class="h5">Cohorts</h2>
+      <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="data_type" value="cohorts" />
+        <div class="mb-3">
+          <input class="form-control" type="file" name="file" accept=".csv" required />
+        </div>
+        <button class="btn btn-primary" type="submit">Import</button>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -12,6 +12,7 @@
         <a class="navbar-brand" href="/">Metaanalaysis cytokines</a>
         <div class="navbar-nav">
           <a class="nav-link" href="{{ url_for('core.studies') }}">Studies</a>
+          <a class="nav-link" href="{{ url_for('core.import_data') }}">Import</a>
         </div>
       </div>
     </nav>

--- a/tests/test_import_page.py
+++ b/tests/test_import_page.py
@@ -1,0 +1,53 @@
+import io
+from app import create_app
+from app.models import db, Study, Cohort
+
+
+def create_test_app():
+    app = create_app()
+    app.config.update(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_import_studies_and_cohorts_via_page():
+    app = create_test_app()
+    client = app.test_client()
+
+    studies_csv = (
+        "study_id,first_author,publication_year,country,study_design,notes\n"
+        "S1,Smith,2020,USA,RCT,note1\n"
+    ).encode("utf-8")
+    resp = client.post(
+        "/import",
+        data={
+            "data_type": "studies",
+            "file": (io.BytesIO(studies_csv), "studies.csv"),
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        assert Study.query.count() == 1
+
+    cohorts_csv = ("study_id,cohort_label,sample_size\n" "S1,Control,10\n").encode(
+        "utf-8"
+    )
+    resp = client.post(
+        "/import",
+        data={
+            "data_type": "cohorts",
+            "file": (io.BytesIO(cohorts_csv), "cohorts.csv"),
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        assert Cohort.query.count() == 1


### PR DESCRIPTION
## Summary
- allow uploading study and cohort data via new CSV import page
- link import page from the main navigation
- cover CSV uploads with tests

## Testing
- ⚠️ `pre-commit run --files app/blueprints/core/routes.py app/templates/layout.html app/templates/import.html tests/test_import_page.py` (failed: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)
- ✅ `black app/blueprints/core/routes.py tests/test_import_page.py`
- ✅ `ruff check app/blueprints/core/routes.py tests/test_import_page.py --fix`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdddb2a2a08328afde7c4473f7cdc3