### PR TITLE
Handle empty numeric fields during cohort import

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -137,11 +137,17 @@ def import_cohorts_from_csv(path: str) -> List[Cohort]:
             row.pop("id", None)
 
             for field in int_fields:
-                if row.get(field):
-                    row[field] = int(row[field])
+                value = row.get(field)
+                if value is None or value.strip() == "":
+                    row[field] = None
+                else:
+                    row[field] = int(value)
             for field in float_fields:
-                if row.get(field):
-                    row[field] = float(row[field])
+                value = row.get(field)
+                if value is None or value.strip() == "":
+                    row[field] = None
+                else:
+                    row[field] = float(value)
             for field in bool_fields:
                 row[field] = _parse_bool(row.get(field))
 

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -28,15 +28,58 @@ def test_import_studies_and_cohorts(tmp_path):
         with study_csv.open('w', newline='') as fh:
             writer = csv.writer(fh)
             writer.writerow(['study_id','first_author','publication_year','country','study_design','notes'])
-            writer.writerow(['S1','Smith','2020','USA','RCT','note1'])
+            writer.writerow(['T1','Smith','2020','USA','RCT','note1'])
         import_studies_from_csv(str(study_csv))
         assert Study.query.count() == 1
         cohort_csv = tmp_path / 'cohorts.csv'
         with cohort_csv.open('w', newline='') as fh:
             writer = csv.writer(fh)
             writer.writerow(['study_id','cohort_label','sample_size'])
-            writer.writerow(['S1','Control','10'])
+            writer.writerow(['T1','Control','10'])
         import_cohorts_from_csv(str(cohort_csv))
         assert Cohort.query.count() == 1
         cohort = Cohort.query.first()
         assert cohort.sample_size == 10
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()
+
+
+def test_import_cohorts_handles_blank_numeric_values(tmp_path):
+    app = setup_app()
+    with app.app_context():
+        db.create_all()
+        study_csv = tmp_path / "studies.csv"
+        with study_csv.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow([
+                "study_id",
+                "first_author",
+                "publication_year",
+                "country",
+                "study_design",
+                "notes",
+            ])
+            writer.writerow(["T2", "Smith", "2020", "USA", "RCT", "note1"])
+        import_studies_from_csv(str(study_csv))
+        cohort_csv = tmp_path / "cohorts.csv"
+        with cohort_csv.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(
+                [
+                    "study_id",
+                    "cohort_label",
+                    "sample_size",
+                    "age_central_value",
+                    "lvef_percent_central",
+                ]
+            )
+            writer.writerow(["T2", "Control", "", "", ""])
+        import_cohorts_from_csv(str(cohort_csv))
+        cohort = Cohort.query.first()
+        assert cohort.sample_size is None
+        assert cohort.age_central_value is None
+        assert cohort.lvef_percent_central is None
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()

--- a/tests/test_import_page.py
+++ b/tests/test_import_page.py
@@ -13,6 +13,7 @@ def create_test_app():
         }
     )
     with app.app_context():
+        db.drop_all()
         db.create_all()
     return app
 


### PR DESCRIPTION
## Summary
- prevent float conversion errors by treating blank numeric CSV fields as `None`
- add tests for importing cohorts with empty numeric values and reset DB in page import tests

## Testing
- `pre-commit run --files app/models.py tests/test_import_csv.py tests/test_import_page.py` *(fails: unable to access 'https://github.com/psf/black/')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde09c41e88328919acc86fd5f8c1e