### PR TITLE
Add sorting and cohort links on studies page

### DIFF
--- a/app/blueprints/core/routes.py
+++ b/app/blueprints/core/routes.py
@@ -11,8 +11,11 @@ from flask import (
 import os
 import tempfile
 
+from sqlalchemy.orm import joinedload
+
 from app.models import (
     Study,
+    Cohort,
     import_cohorts_from_csv,
     import_studies_from_csv,
 )
@@ -34,9 +37,35 @@ def index():
 
 @bp.get("/studies")
 def studies():
-    """List available studies."""
-    all_studies = Study.query.order_by(Study.publication_year.desc()).all()
-    return render_template("studies.html", studies=all_studies)
+    """List available studies with optional sorting."""
+    sort_key = request.args.get("sort", "publication_year")
+    direction = request.args.get("direction", "desc")
+    sort_options = {
+        "id": Study.id,
+        "study_id": Study.study_id,
+        "first_author": Study.first_author,
+        "publication_year": Study.publication_year,
+        "country": Study.country,
+        "study_design": Study.study_design,
+        "notes": Study.notes,
+    }
+    sort_col = sort_options.get(sort_key, Study.publication_year)
+    order_by = sort_col.asc() if direction == "asc" else sort_col.desc()
+    all_studies = (
+        Study.query.options(joinedload(Study.cohorts))
+        .order_by(order_by)
+        .all()
+    )
+    return render_template(
+        "studies.html", studies=all_studies, sort=sort_key, direction=direction
+    )
+
+
+@bp.get("/cohorts/<int:cohort_id>")
+def cohort_detail(cohort_id: int):
+    """Display details for a cohort."""
+    cohort = Cohort.query.get_or_404(cohort_id)
+    return render_template("cohort_detail.html", cohort=cohort)
 
 
 @bp.route("/import", methods=["GET", "POST"])

--- a/app/templates/cohort_detail.html
+++ b/app/templates/cohort_detail.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+{% block title %}Cohort {{ cohort.cohort_label }}{% endblock %}
+{% block content %}
+  <h1 class="h3 mb-3">Cohort: {{ cohort.cohort_label }}</h1>
+  <dl class="row">
+    <dt class="col-sm-3">Study ID</dt>
+    <dd class="col-sm-9">{{ cohort.study_id }}</dd>
+    <dt class="col-sm-3">Notes</dt>
+    <dd class="col-sm-9">{{ cohort.cohort_notes or '' }}</dd>
+    <dt class="col-sm-3">Sample size</dt>
+    <dd class="col-sm-9">{{ cohort.sample_size or 'N/A' }}</dd>
+  </dl>
+  <a href="{{ url_for('core.studies') }}">Back to studies</a>
+{% endblock %}

--- a/app/templates/studies.html
+++ b/app/templates/studies.html
@@ -8,13 +8,13 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th scope="col">ID</th>
-          <th scope="col">Study ID</th>
-          <th scope="col">First author</th>
-          <th scope="col">Year</th>
-          <th scope="col">Country</th>
-          <th scope="col">Study type</th>
-          <th scope="col">Notes</th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='id', direction='asc' if sort != 'id' or direction == 'desc' else 'desc') }}">ID</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='study_id', direction='asc' if sort != 'study_id' or direction == 'desc' else 'desc') }}">Study ID</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='first_author', direction='asc' if sort != 'first_author' or direction == 'desc' else 'desc') }}">First author</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='publication_year', direction='asc' if sort != 'publication_year' or direction == 'desc' else 'desc') }}">Year</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='country', direction='asc' if sort != 'country' or direction == 'desc' else 'desc') }}">Country</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='study_design', direction='asc' if sort != 'study_design' or direction == 'desc' else 'desc') }}">Study type</a></th>
+          <th scope="col"><a href="{{ url_for('core.studies', sort='notes', direction='asc' if sort != 'notes' or direction == 'desc' else 'desc') }}">Notes</a></th>
         </tr>
       </thead>
       <tbody>
@@ -28,6 +28,17 @@
             <td>{{ study.study_design }}</td>
             <td>{{ study.notes }}</td>
           </tr>
+          {% if study.cohorts %}
+            <tr>
+              <td colspan="7">
+                <ul class="mb-0">
+                  {% for cohort in study.cohorts %}
+                    <li><a href="{{ url_for('core.cohort_detail', cohort_id=cohort.cohort_id) }}">{{ cohort.cohort_label }}</a></li>
+                  {% endfor %}
+                </ul>
+              </td>
+            </tr>
+          {% endif %}
         {% endfor %}
       </tbody>
     </table>

--- a/tests/test_studies_page.py
+++ b/tests/test_studies_page.py
@@ -1,0 +1,43 @@
+from app import create_app
+from app.models import db, Study, Cohort
+
+
+def create_test_app():
+    app = create_app()
+    app.config.update(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def test_sorting_and_cohort_links():
+    app = create_test_app()
+    with app.app_context():
+        s1 = Study(study_id="S1", first_author="Beta", publication_year=2019)
+        s2 = Study(study_id="S2", first_author="Alpha", publication_year=2020)
+        db.session.add_all([s1, s2])
+        db.session.flush()
+        c1 = Cohort(study_id="S1", cohort_label="Control")
+        c2 = Cohort(study_id="S2", cohort_label="Treatment")
+        db.session.add_all([c1, c2])
+        db.session.commit()
+        cohort_id = c1.cohort_id
+
+    client = app.test_client()
+    resp = client.get("/studies?sort=first_author&direction=asc")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert body.find("Alpha") < body.find("Beta")
+    assert "Control" in body
+    assert f"/cohorts/{cohort_id}" in body
+
+    resp = client.get(f"/cohorts/{cohort_id}")
+    assert resp.status_code == 200
+    assert "Control" in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add sorting options for study list
- display associated cohorts beneath each study with detail links
- introduce cohort detail page
- test ordering and cohort navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde56072ac83289e0155fba79f70cb