### PR TITLE
Handle blank summary type enums in cohort import

### DIFF
--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -83,3 +83,33 @@ def test_import_cohorts_handles_blank_numeric_values(tmp_path):
         db.session.remove()
         db.drop_all()
         db.engine.dispose()
+
+
+def test_import_cohorts_handles_blank_summary_type(tmp_path):
+    app = setup_app()
+    with app.app_context():
+        db.create_all()
+        study_csv = tmp_path / "studies.csv"
+        with study_csv.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow([
+                "study_id",
+                "first_author",
+                "publication_year",
+                "country",
+                "study_design",
+                "notes",
+            ])
+            writer.writerow(["T3", "Smith", "2020", "USA", "RCT", "note1"])
+        import_studies_from_csv(str(study_csv))
+        cohort_csv = tmp_path / "cohorts.csv"
+        with cohort_csv.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["study_id", "cohort_label", "lvedd_summary_type"])
+            writer.writerow(["T3", "Control", ""])
+        import_cohorts_from_csv(str(cohort_csv))
+        cohort = Cohort.query.first()
+        assert cohort.lvedd_summary_type is None
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()


### PR DESCRIPTION
## Summary
- normalize blank or invalid summary type strings to `NULL` during cohort CSV import
- add regression test for importing cohorts with blank summary type values

## Testing
- `pytest -q`
- `pre-commit run --files app/models.py tests/test_import_csv.py` *(fails: unable to access 'https://github.com/psf/black/' - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bde78fc5348328b29527417f40cd9e