### PR TITLE
Handle blank summary types in cohorts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,9 +4,27 @@ import csv
 from typing import List
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.types import String, TypeDecorator
 
 
 db = SQLAlchemy()
+
+
+class SummaryType(TypeDecorator):
+    """String column that normalises blank values to ``None``."""
+
+    impl = String(20)
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):  # type: ignore[override]
+        if value is None or value == "":
+            return None
+        return value
+
+    def process_result_value(self, value, dialect):  # type: ignore[override]
+        if value is None or value == "":
+            return None
+        return value
 
 
 class Study(db.Model):
@@ -38,9 +56,7 @@ class Cohort(db.Model):
     sample_size = db.Column(db.Integer)
     age_central_value = db.Column(db.Float)
     age_dispersion_value = db.Column(db.Float)
-    age_summary_type = db.Column(
-        db.Enum("mean_sd", "median_iqr", name="age_summary_type")
-    )
+    age_summary_type = db.Column(SummaryType())
     percent_male = db.Column(db.Float)
     ethnicity = db.Column(db.String)
     inflammation_excluded_by_emb = db.Column(db.Boolean)
@@ -50,14 +66,10 @@ class Cohort(db.Model):
     nyha_summary = db.Column(db.String)
     lvef_percent_central = db.Column(db.Float)
     lvef_percent_dispersion = db.Column(db.Float)
-    lvef_summary_type = db.Column(
-        db.Enum("mean_sd", "median_iqr", name="lvef_summary_type")
-    )
+    lvef_summary_type = db.Column(SummaryType())
     lvedd_central = db.Column(db.Float)
     lvedd_dispersion = db.Column(db.Float)
-    lvedd_summary_type = db.Column(
-        db.Enum("mean_sd", "median_iqr", name="lvedd_summary_type")
-    )
+    lvedd_summary_type = db.Column(SummaryType())
     emb_performed = db.Column(db.Boolean)
     emb_criteria = db.Column(db.Text)
     emb_lymphocyte_density_per_mm2 = db.Column(db.Float)

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -113,3 +113,23 @@ def test_import_cohorts_handles_blank_summary_type(tmp_path):
         db.session.remove()
         db.drop_all()
         db.engine.dispose()
+
+
+def test_existing_blank_summary_type_in_db(tmp_path):
+    app = setup_app()
+    with app.app_context():
+        db.create_all()
+        study = Study(study_id="T4", first_author="Smith")
+        db.session.add(study)
+        db.session.commit()
+        db.session.execute(
+            Cohort.__table__.insert().values(
+                study_id="T4", cohort_label="Control", lvedd_summary_type=""
+            )
+        )
+        db.session.commit()
+        cohort = Cohort.query.first()
+        assert cohort.lvedd_summary_type is None
+        db.session.remove()
+        db.drop_all()
+        db.engine.dispose()


### PR DESCRIPTION
## Summary
- allow blank summary type values by introducing a custom SummaryType column
- cover blank values already in the database

## Testing
- `pre-commit run --files app/models.py tests/test_import_csv.py` *(fails: unable to access https://github.com/psf/black/, CONNECT tunnel failed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdeb1e4528832887cb611492f0d9fd